### PR TITLE
fix: resolve broken blog image paths in OpenClaw post

### DIFF
--- a/site/blog/2026-03-14-hosting-multiple-openclaw-agents-with-docker.md
+++ b/site/blog/2026-03-14-hosting-multiple-openclaw-agents-with-docker.md
@@ -7,7 +7,7 @@ description: "How I set up multiple isolated OpenClaw instances on a single Ubun
 keywords: [OpenClaw, Docker, nginx, certbot, Ubuntu, VPS, DigitalOcean, reverse proxy, AI agents]
 ---
 
-![OpenClaw hero](openclaw-hero.png)
+![OpenClaw hero](/img/openclaw-hero.png)
 
 [OpenClaw](https://openclaw.ai/) is the hot new thing in the world of AI and tech. It's a fairly open ended tool that allows you to run a personalized AI agent on your own hardware. It can run command line tools, perform web searches, write code, run desktop apps, and perform scheduled tasks, making it an excellent personal aid. All of that is paired with its extensive communication integrations, which allow you to chat with and control it through almost any messaging app.
 
@@ -608,7 +608,7 @@ sudo docker restart claw-name
 ```
 You should now be able to access the dashboard via a web browser using your configured (sub)domain.
 
-![OpenClaw dashboard](openclaw-gateway-connect.png)
+![OpenClaw dashboard](/img/openclaw-gateway-connect.png)
 
 Open the "Overview" page and enter the gateway token `OPENCLAW_GATEWAY_TOKEN` you configured in your `/opt/claws/claw-name/.env` file and press "Connect".
 


### PR DESCRIPTION
### Motivation
- CI production builds were failing because MDX reported unresolved local image paths referenced from the OpenClaw blog post.
- The blog references target images that exist under `site/static/img/`, so they must use the Docusaurus static URL form to be found during build.

### Description
- Updated `site/blog/2026-03-14-hosting-multiple-openclaw-agents-with-docker.md` to replace `openclaw-hero.png` and `openclaw-gateway-connect.png` with `/img/openclaw-hero.png` and `/img/openclaw-gateway-connect.png` respectively so Docusaurus resolves them from `site/static/img/`.
- Change is limited to those two image references in the single blog post and does not alter any other content.

### Testing
- Ran `cd site && npm run build` and the Docusaurus production build completed successfully and generated static files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c082f3cc832fb495b9d3b2a19fe6)