### PR TITLE
fix: render blog disclaimer footer on post pages

### DIFF
--- a/site/src/theme/BlogPostItem/Footer/index.tsx
+++ b/site/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import OriginalBlogPostItemFooter from '@theme-original/BlogPostItem/Footer';
-import type {Props} from '@theme/BlogPostItem/Footer';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 
-export default function BlogPostItemFooter(props: Props): JSX.Element {
+export default function BlogPostItemFooter(): JSX.Element {
+  const {isBlogPostPage} = useBlogPost();
+
   return (
     <>
-      <OriginalBlogPostItemFooter {...props} />
-      {props.isBlogPostPage ? (
+      <OriginalBlogPostItemFooter />
+      {isBlogPostPage ? (
         <section className="author-disclaimer-footer">
           <h2 className="author-disclaimer-footer__title">About the Author</h2>
           <p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the blog post footer theme override so it detects full post pages correctly
- switch from reading `isBlogPostPage` from props to using Docusaurus `useBlogPost()` context
- keep the reusable "About the Author" + "Disclaimer" section rendering only on full blog post pages

## Validation
- `cd site && npm run build` succeeded
- verified generated HTML contains the new footer text on:
  - `/blog/2026-hosting-multiple-openclaw-agents-with-docker/`
  - `/blog/welcome/`
  - `/blog/aspnet-core-minimal-apis-tips/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4aeec4b-a221-4449-a2fa-488c46a9adf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4aeec4b-a221-4449-a2fa-488c46a9adf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

