### PR TITLE
chore(rules): enforce pull request workflow instead of direct main pushes

### DIFF
--- a/.agents/rules/pull-requests.md
+++ b/.agents/rules/pull-requests.md
@@ -1,5 +1,9 @@
 # Pull Requests
 
+## Workflow Guidelines
+
+- **Always Create a Pull Request**: Never push changes directly to the `main` branch. All work must be performed on a dedicated branch, pushed to the remote repository, and a Pull Request opened for user review.
+
 ## Code Guidelines
 
 - Adhere to defined coding guidelines.


### PR DESCRIPTION
Added a Workflow Guidelines section to .agents/rules/pull-requests.md. This requires that all future repository modifications are performed on dedicated branches and merged via Pull Requests rather than being pushed directly to the main branch. This aligns developer workflow expectations with best practices.