### PR TITLE
docs(blog): fix bash history expansion error in git helper example

### DIFF
--- a/site/blog/2026-github-apps-for-personal-automation/index.md
+++ b/site/blog/2026-github-apps-for-personal-automation/index.md
@@ -152,7 +152,7 @@ TOKEN=$(/opt/sync/get-github-token.sh)
 git clone https://x-access-token:${TOKEN}@github.com/your-username/my-configs.git /opt/configs
 
 # Option B: Run a pull command without caching credentials permanently
-git -c credential.helper= -c "credential.helper=!f() { echo password=$TOKEN; }; f" pull
+git -c credential.helper= -c 'credential.helper=!f() { echo password='$TOKEN'; }; f' pull
 ```
 
 ---


### PR DESCRIPTION
Updated the inline git credential helper command in site/blog/2026-github-apps-for-personal-automation/index.md to enclose the exclamation mark in single quotes. This prevents Bash from attempting history expansion (which causes the '-bash: !f: event not found' error in interactive shells) while still allowing bash to expand the  variable correctly.