### PR TITLE
docs(git-auth): added git-push script to scenario 1

### DIFF
--- a/site/blog/2026-github-apps-for-personal-automation/index.md
+++ b/site/blog/2026-github-apps-for-personal-automation/index.md
@@ -175,7 +175,8 @@ Below is a recommended folder structure for your server configuration repository
     ├── .gitignore              # Ignores local private credentials
     ├── github-app.private-key.pem # Local private key file (ignored)
     ├── get-github-token.sh     # Executable token exchange script
-    └── git-pull.sh             # Sync trigger wrapper script
+    ├── git-pull.sh             # Sync trigger pull script
+    └── git-push.sh             # Sync trigger push script
 ```
 
 #### 1. `.gitignore` (Root)
@@ -210,9 +211,26 @@ TOKEN=$("${SCRIPT_DIR}/get-github-token.sh")
 git -c credential.helper= -c 'credential.helper=!f() { echo password='$TOKEN'; }; f' pull
 ```
 
+#### 4. `git/git-push.sh`
+Create a corresponding wrapper script that automatically requests a new token, performs the git push (forwarding any branch/tag arguments), and exits cleanly:
+```bash
+#!/usr/bin/env bash
+# git/git-push.sh: Securely push local configuration changes using GitHub App credentials
+set -euo pipefail
+
+# Determine script directory to locate get-github-token.sh relatively
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Retrieve a temporary access token (valid for 1 hour)
+TOKEN=$("${SCRIPT_DIR}/get-github-token.sh")
+
+# Run git push forwarding all script arguments (e.g. git-push.sh origin main)
+git -c credential.helper= -c 'credential.helper=!f() { echo password='$TOKEN'; }; f' push "$@"
+```
+
 Make the sync scripts executable on the host server:
 ```bash
-chmod +x git/get-github-token.sh git/git-pull.sh
+chmod +x git/get-github-token.sh git/git-pull.sh git/git-push.sh
 ```
 
 ---


### PR DESCRIPTION
Added a corresponding git-push.sh wrapper script example to the server configuration sync scenario (Scenario 1) in site/blog/2026-github-apps-for-personal-automation/index.md. The script fetches a temporary installation access token and executes git push securely (forwarding all arguments). Also updated the directory structure visualization and the chmod executable command references to include git-push.sh. Mirrored these additions into the corresponding Obsidian vault note.