### PR TITLE
docs(blog): standardize date metadata

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -14,7 +14,7 @@ The site will be available at `http://localhost:3000`.
 
 ## Writing a Blog Post
 
-Create a new Markdown file in the `blog/` directory. The filename should follow the format `YYYY-MM-DD-slug.md`.
+Create a new directory in the `blog/` folder. The directory name should follow the format `YYYY-slug` (e.g., `2026-my-post`), and the main file should be named `index.md`. This folder-based layout allows you to co-locate images and other assets with your posts. For simple, asset-free posts, you can also write a standalone file named `YYYY-slug.md`.
 
 ### Minimal post template
 
@@ -22,6 +22,10 @@ Create a new Markdown file in the `blog/` directory. The filename should follow 
 ---
 slug: my-post-slug
 title: "Post Title Here"
+date: 2026-07-12
+last_update:
+  date: 2026-07-12
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [dotnet, tips]
@@ -42,6 +46,8 @@ Rest of the post content goes here. Use standard Markdown.
 | ------------- | -------- | ------------------------------------------ |
 | `slug`        | Yes      | URL path for the post (`/blog/{slug}`)     |
 | `title`       | Yes      | Post title                                 |
+| `date`        | Yes      | Original publication date (`YYYY-MM-DD`)    |
+| `last_update` | No       | Last edit date and author override block   |
 | `authors`     | Yes      | Inline author metadata for SEO tags        |
 | `tags`        | Yes      | Tag key(s) from `blog/tags.yml`            |
 | `description` | Yes      | SEO meta description / social card summary |

--- a/site/blog/2026-aspnet-core-minimal-apis-tips/index.md
+++ b/site/blog/2026-aspnet-core-minimal-apis-tips/index.md
@@ -1,6 +1,10 @@
 ---
 slug: aspnet-core-minimal-apis-tips
 title: "5 Things I Wish I Knew Sooner About ASP.NET Core Minimal APIs"
+date: 2026-02-22
+last_update:
+  date: 2026-03-18
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [aspnet, dotnet, csharp, tips]

--- a/site/blog/2026-github-apps-for-personal-automation/index.md
+++ b/site/blog/2026-github-apps-for-personal-automation/index.md
@@ -1,6 +1,10 @@
 ---
 slug: 2026-github-apps-for-personal-automation
 title: "GitHub Apps for Personal Automation: Secure, Granular Access Control"
+date: 2026-06-08
+last_update:
+  date: 2026-06-08
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [github, github-apps, automation, security, devops, open-claw, vps]

--- a/site/blog/2026-hosting-multiple-openclaw-agents-with-docker/index.md
+++ b/site/blog/2026-hosting-multiple-openclaw-agents-with-docker/index.md
@@ -1,6 +1,10 @@
 ---
 slug: 2026-hosting-multiple-openclaw-agents-with-docker
 title: "Hosting Multiple OpenClaw Agents with Docker"
+date: 2026-03-14
+last_update:
+  date: 2026-03-18
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [open-claw, docker, ai, agentic-ai, nginx, compose, ubuntu, vps, digital-ocean]

--- a/site/blog/2026-macos-github-actions-runner-fleet/index.md
+++ b/site/blog/2026-macos-github-actions-runner-fleet/index.md
@@ -1,6 +1,10 @@
 ---
 slug: 2026-macos-github-actions-runner-fleet
 title: "Running a Small GitHub Actions Runner Fleet on macOS"
+date: 2026-07-11
+last_update:
+  date: 2026-07-11
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [github, github-actions, macos, automation, devops]

--- a/site/blog/2026-welcome/index.md
+++ b/site/blog/2026-welcome/index.md
@@ -1,6 +1,10 @@
 ---
 slug: welcome
 title: "Welcome to My Blog"
+date: 2026-02-22
+last_update:
+  date: 2026-03-18
+  author: Zach Cutler
 authors:
   - name: Zach Cutler
 tags: [discovery]


### PR DESCRIPTION
Move ASP.NET Core Minimal APIs post into a directory structure matching the others. Rename 2026-02-22-welcome folder to 2026-welcome. Add publish date and edit last_update fields to the front matter of all blog posts. Update blog post writing instructions in site/README.md.