### PR TITLE
fix(site): update footer github and linkedin urls

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -129,11 +129,11 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/zachcutler',
+              href: 'https://github.com/linkofdarkness',
             },
             {
               label: 'LinkedIn',
-              href: 'https://linkedin.com/in/zachcutler',
+              href: 'https://linkedin.com/in/zacharytcutler',
             },
           ],
         },


### PR DESCRIPTION
Updated the GitHub and LinkedIn footer URLs to match the correct ones configured in the header (navbar).